### PR TITLE
ci: adopt rainix nix-cachix-setup composite, drop deprecated DeterminateSystems nix installer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,9 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix develop -c npm run test


### PR DESCRIPTION
Closes #4

## What

Replaces the deprecated `DeterminateSystems/nix-installer-action` (+ `magic-nix-cache-action`) in `.github/workflows/test.yaml` with the org-standard shared composite `rainlanguage/rainix/.github/actions/nix-cachix-setup@main`, which bundles nix-quick-install + Cachix + `cache-nix-action` and pins every third-party action to an exact SHA (single source of truth — "rainix owns shared CI"). The pre-existing `actions/checkout@v4` step is kept, so the composite is called with `checkout: 'false'`.

This is the same swap already applied and green on the pilot PRs rainlanguage/rain.chainlink#11 and rainlanguage/rain.tier.interface#8.

## QA

CI-infrastructure-only change: it touches a single GitHub Actions workflow file and no source or test code, so there is no behavioral code surface to mutation-test — the discriminating oracle is the CI run itself.

- **Discriminating oracle:** the `Test` job must install Nix and run `nix develop -c npm run test` with the composite in place of the removed installer. A mis-reference (wrong action path or input name) fails the setup step, so the swap is CI-green-discriminating, not a silent no-op.
- **Independent confirmation:** the identical composite swap is already green on the pilots rain.chainlink#11 / rain.tier.interface#8; the composite's input contract (`checkout`, `cachix-auth-token`) was verified against `nix-cachix-setup/action.yml` on `rainix@main`.
- **Equivalence:** the composite provides the same capabilities the removed steps did (Nix install + a Nix store cache) plus the org's pinned-SHA hardening. `checkout: 'false'` preserves the existing `actions/checkout@v4` (submodules recursive, fetch-depth 0). An empty `CACHIX_AUTH_TOKEN` degrades to a read-only Cachix pull (the composite's documented default), so the job stays green whether or not the repo sets that secret.
- **Category check:** issue asks to replace the deprecated installer with the org-standard install (preferred: adopt the shared composite) and verify CI stays green — done → Closes #4.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow’s Nix caching setup to improve build environment configuration.
  * Reused the configured cache authentication securely through repository secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->